### PR TITLE
PA4.1

### DIFF
--- a/nanos-lite/src/device.c
+++ b/nanos-lite/src/device.c
@@ -57,7 +57,7 @@ size_t fb_write(const void *buf, size_t offset, size_t len) {
  
   int y = offset / width;
   int x = offset % width;
-  io_write(AM_GPU_FBDRAW, x, y, (void *)buf, len, 300, true);
+  io_write(AM_GPU_FBDRAW, x, y, (void *)buf, len, 1, true);
   return len;
 }
 

--- a/nanos-lite/src/fs.c
+++ b/nanos-lite/src/fs.c
@@ -72,7 +72,8 @@ int fs_close(int fd){
 size_t fs_read(int fd, void *buf, size_t len){
   ReadFn real_read = file_table[fd].read;
   if(real_read != NULL){
-    return real_read(buf,0,len);
+    size_t open_offset = file_table[fd].open_offset;
+    return real_read(buf,open_offset,len);
   }
   size_t read_len = len;
   size_t open_offset = file_table[fd].open_offset;
@@ -91,7 +92,8 @@ size_t fs_read(int fd, void *buf, size_t len){
 size_t fs_write(int fd, void *buf, size_t len){
   WriteFn real_write = file_table[fd].write;
   if(real_write != NULL){
-    return real_write(buf,0,len);
+    size_t open_offset = file_table[fd].open_offset;
+    return real_write(buf,open_offset,len);
   }
   size_t write_len = len;
   size_t open_offset = file_table[fd].open_offset;

--- a/nanos-lite/src/proc.c
+++ b/nanos-lite/src/proc.c
@@ -123,16 +123,17 @@ void context_uload(PCB *pcb, const char *filename,char *const argv[],char *const
 void init_proc() {
   //char *A = "M";
   char *B = "B";
-  //char *argv[] = {"/bin/pal", "--skip", NULL};
+  char *argv[] = {"/bin/pal", "--skip", NULL};
   //printf("%s %s\n",argv[0],argv[1]);
   context_kload(&pcb[0], hello_fun,(void*)B);
-  //context_uload(&pcb[1], "/bin/pal", argv, NULL);
-  char *argv[] = {"/bin/nterm",NULL,NULL};
+  context_uload(&pcb[1], "/bin/pal", argv, NULL);
+  //char *argv[] = {"/bin/nterm",NULL,NULL};
   //char *argv[] = {"/bin/menu",NULL,NULL};
   //char *argv[] = {"/bin/exec-test",NULL,NULL};
   //context_uload(&pcb[1],"/bin/exec-test",argv,NULL);
   //context_uload(&pcb[1],"/bin/menu",argv,NULL);
-  context_uload(&pcb[1],"/bin/nterm",argv,NULL);
+  //char *argv[] = {"/bin/vga-test",NULL,NULL};
+  //context_uload(&pcb[1],"/bin/vga-test",argv,NULL);
   switch_boot_pcb();
 
   Log("Initializing processes...");

--- a/navy-apps/libs/libndl/NDL.c
+++ b/navy-apps/libs/libndl/NDL.c
@@ -80,7 +80,7 @@ void NDL_OpenCanvas(int *w, int *h) {
 void NDL_DrawRect(uint32_t *pixels, int x, int y, int w, int h) {
   int fd = open("/dev/fb");
   //printf("fd = %d\n",fd);
-  for (int i = 0; i < 1; i++) { 
+  for (int i = 0; i < h; i++) { 
     lseek(fd, ((y + i) * screen_w + x) * 4, SEEK_SET);
     write(fd, pixels + i * w, 4*w);
     //printf("%d\n",i);


### PR DESCRIPTION
1. 由于fs_write和fs_read中处理特殊文件时传入参数错误导致绘制图片错误，已更正